### PR TITLE
Fix redirection

### DIFF
--- a/conf.d/__fasd_run.fish
+++ b/conf.d/__fasd_run.fish
@@ -1,6 +1,6 @@
 function __fasd_run -e fish_postexec -d "fasd takes record of the directories changed into"
   set -lx RETVAL $status
   if test $RETVAL -eq 0 # if there was no error
-    command fasd --proc (command fasd --sanitize (eval echo "$argv") | tr -s " " \n) > "/dev/null" 2>&1 &
+    command fasd --proc (command fasd --sanitize "$argv" | tr -s " " \n) > "/dev/null" 2>&1 &
   end
 end


### PR DESCRIPTION
The `eval echo` breaks redirection in fish